### PR TITLE
Fix frontend tests: repair tsconfig and update stale spec

### DIFF
--- a/app/frontend/src/app/containers/app/app.component.spec.ts
+++ b/app/frontend/src/app/containers/app/app.component.spec.ts
@@ -1,12 +1,27 @@
 import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { StoreModule } from '@ngrx/store';
+import { EffectsModule } from '@ngrx/effects';
+
 import { AppComponent } from './app.component';
+import { reducers } from '../../../auth/store/reducers';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [
-        AppComponent
+      imports: [
+        RouterTestingModule,
+        NoopAnimationsModule,
+        MatToolbarModule,
+        FontAwesomeModule,
+        StoreModule.forRoot({}),
+        StoreModule.forFeature('AuthState', reducers),
+        EffectsModule.forRoot([]),
       ],
+      declarations: [AppComponent],
     }).compileComponents();
   });
 
@@ -16,16 +31,18 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have as title 'amazing-employees'`, () => {
+  it('should initialize loading as false', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual('amazing-employees');
+    expect(app.loading).toBeFalse();
   });
 
-  it('should render title', () => {
+  it('should render the toolbar with app title', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
-    const compiled = fixture.nativeElement;
-    expect(compiled.querySelector('.content span').textContent).toContain('amazing-employees app is running!');
+    const compiled = fixture.nativeElement as HTMLElement;
+    const toolbar = compiled.querySelector('mat-toolbar');
+    expect(toolbar).toBeTruthy();
+    expect(toolbar!.textContent).toContain('Employees who amazes!');
   });
 });

--- a/app/frontend/tsconfig.json
+++ b/app/frontend/tsconfig.json
@@ -29,9 +29,6 @@
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
-    "strictTemplates": true,
-    "types": [
-      "node"
-    ]
+    "strictTemplates": true
   }
 }


### PR DESCRIPTION
Two issues prevented frontend tests from running:

1. tsconfig.json had 'types: ["node"]' inside angularCompilerOptions, which overrode compilerOptions.types in tsconfig.spec.json during Angular's Karma builder compilation. This caused jasmine globals (describe, it, expect) to be unresolvable. Moved types out of angularCompilerOptions to fix the override.

2. app.component.spec.ts was a stale Angular CLI scaffold that referenced a non-existent 'title' property and DOM selectors not present in the actual template. Rewrote with proper TestBed setup (NgRx Store, Router, Material, FontAwesome) and tests matching the real AppComponent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test setup and TypeScript config; main risk is unintended side effects on Angular/Karma compilation if other tooling relied on the previous `tsconfig.json` typing behavior.
> 
> **Overview**
> Fixes broken frontend test compilation by removing the misplaced `types: ["node"]` entry from `angularCompilerOptions` in `tsconfig.json` so spec typings from `tsconfig.spec.json` (e.g., Jasmine globals) are no longer overridden.
> 
> Updates `app.component.spec.ts` from the stale Angular CLI scaffold to a real `TestBed` setup (router, Material toolbar, FontAwesome, NgRx store/effects) and replaces outdated assertions with checks for `loading` initialization and toolbar title rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d751a9a22f01d0604f6236dc3a4830457086be0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->